### PR TITLE
Add opensm-devel to RPM build requirements

### DIFF
--- a/dist/infiniband-radar-daemon.spec
+++ b/dist/infiniband-radar-daemon.spec
@@ -13,7 +13,7 @@ License:	GPLv3
 URL:		https://github.com/infiniband-radar/%{name}
 Source0:	https://github.com/infiniband-radar/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 
-BuildRequires:  cmake3 gcc-c++ libibmad-devel infiniband-diags-devel libcurl-devel
+BuildRequires:  cmake3 gcc-c++ libibmad-devel infiniband-diags-devel libcurl-devel opensm-devel
 %{?systemd_requires}
 BuildRequires: systemd
 Requires:       libibmad infiniband-diags libcurl


### PR DESCRIPTION
Without opensm-devel installed, attempts to build the RPM on RHEL7.9
failed with errors about missing "iba/ib_types.h".

This commit adds opensm-devel to the build requirements in the sample
spec file and I was successful in building the RPM.

closes: #23 